### PR TITLE
Update to 1.16.0 and include support for OpenSSL 1.1.1 on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,7 @@
+if "%ARCH%" == "32" (set PLATFORM=x86) else (set PLATFORM=x64)
+
 set "GRPC_PYTHON_BUILD_SYSTEM_ZLIB=True"
 set "GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True"
-set "GRPC_PYTHON_CFLAGS=/DPB_FIELD_16BIT"
 
 "%PYTHON%" -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 if errorlevel 1 exit 1

--- a/recipe/extra_include_and_lib_dirs.patch
+++ b/recipe/extra_include_and_lib_dirs.patch
@@ -1,0 +1,27 @@
+diff --git a/setup.py b/setup.py
+index 5eb54b4..e67ba8c 100644
+--- a/setup.py
++++ b/setup.py
+@@ -183,6 +183,14 @@ if BUILD_WITH_SYSTEM_CARES:
+ EXTENSION_INCLUDE_DIRECTORIES = (
+     (PYTHON_STEM,) + CORE_INCLUDE + SSL_INCLUDE + ZLIB_INCLUDE +
+     NANOPB_INCLUDE + CARES_INCLUDE + ADDRESS_SORTING_INCLUDE)
++EXTENSION_LIB_DIRECTORIES = ()
++if "win32" in sys.platform:
++  LIBRARY_INC = os.environ.get('LIBRARY_INC', None)
++  if LIBRARY_INC is not None:
++    EXTENSION_INCLUDE_DIRECTORIES += (LIBRARY_INC, )
++  LIBRARY_LIB = os.environ.get('LIBRARY_LIB', None)
++  if LIBRARY_LIB is not None:
++    EXTENSION_LIB_DIRECTORIES += (LIBRARY_LIB, )
+ 
+ EXTENSION_LIBRARIES = ()
+ if "linux" in sys.platform:
+@@ -251,6 +259,7 @@ def cython_extensions_and_necessity():
+           sources=[module_file] + list(CYTHON_HELPER_C_FILES) + core_c_files,
+           include_dirs=list(EXTENSION_INCLUDE_DIRECTORIES),
+           libraries=list(EXTENSION_LIBRARIES),
++          library_dirs=list(EXTENSION_LIB_DIRECTORIES),
+           define_macros=list(DEFINE_MACROS),
+           extra_objects=extra_objects,
+           extra_compile_args=list(CFLAGS),

--- a/recipe/macos_use_distutils.patch
+++ b/recipe/macos_use_distutils.patch
@@ -21,10 +21,19 @@ index 388e629..5eb54b4 100644
        _extension.Extension(
            name=module_name,
 diff --git a/src/python/grpcio/commands.py b/src/python/grpcio/commands.py
-index 4c2ebae..24e835d 100644
+index 0a30971..44b1eff 100644
 --- a/src/python/grpcio/commands.py
 +++ b/src/python/grpcio/commands.py
-@@ -253,29 +253,6 @@ class BuildExt(build_ext.build_ext):
+@@ -57,7 +57,7 @@ Glossary
+ .. glossary::
+ 
+   metadatum
+-    A key-value pair included in the HTTP header.  It is a 
++    A key-value pair included in the HTTP header.  It is a
+     2-tuple where the first entry is the key and the
+     second is the value, i.e. (key, value).  The metadata key is an ASCII str,
+     and must be a valid HTTP header name.  The metadata value can be
+@@ -253,38 +253,6 @@ class BuildExt(build_ext.build_ext):
      LINK_OPTIONS = {}
  
      def build_extensions(self):
@@ -40,8 +49,17 @@ index 4c2ebae..24e835d 100644
 -                os.path.join(target_path, 'libgpr.a'),
 -                os.path.join(target_path, 'libgrpc.a')
 -            ]
+-            # Running make separately for Mac means we lose all
+-            # Extension.define_macros configured in setup.py. Re-add the macro
+-            # for gRPC Core's fork handlers.
+-            # TODO(ericgribkoff) Decide what to do about the other missing core
+-            #   macros, including GRPC_ENABLE_FORK_SUPPORT, which defaults to 1
+-            #   on Linux but remains unset on Mac.
+-            extra_defines = [
+-                'EXTRA_DEFINES="GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1"'
+-            ]
 -            make_process = subprocess.Popen(
--                ['make'] + targets,
+-                ['make'] + extra_defines + targets,
 -                stdout=subprocess.PIPE,
 -                stderr=subprocess.PIPE)
 -            make_out, make_err = make_process.communicate()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
     - macos_use_distutils.patch
     - windows_ssl_lib_names.patch             # [win and openssl != "1.1.1"]
     - windows_ssl_lib_names_openssl111.patch  # [win and openssl == "1.1.1"]
+    - extra_include_and_lib_dirs.patch        # [win]
 
 build:
   number: 1000
@@ -19,8 +20,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}     # [not win]
+    - {{ compiler('cxx') }}   # [not win]
   host:
     - python
     - pip
@@ -30,6 +31,8 @@ requirements:
     - zlib
     - openssl
     - c-ares            # [unix]
+    - m2w64-toolchain   # [win]
+    - libpython         # [win]
   run:
     - python
     - setuptools
@@ -39,6 +42,7 @@ requirements:
     - zlib
     - openssl
     - {{ pin_compatible("c-ares") }}  # [unix]
+    - m2w64-gcc-libs   # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.14.1" %}
+{% set version = "1.16.0" %}
 
 package:
   name: grpcio
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/grpcio/grpcio-{{ version }}.tar.gz
-  sha256: 4bf23666e763ca7ff6010465864e9f088f4ac7ecc1e11abd6f85b250e66b2c05
+  sha256: 0cc5f2d3ee21c642d8982f197c83053fd3a8cbcd6a60240d8c87c6c256b10d57
   patches:
     - macos_use_distutils.patch
     - windows_ssl_lib_names.patch             # [win and openssl != "1.1.1"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,8 @@ source:
   sha256: 4bf23666e763ca7ff6010465864e9f088f4ac7ecc1e11abd6f85b250e66b2c05
   patches:
     - macos_use_distutils.patch
-    - windows_ssl_lib_names.patch
+    - windows_ssl_lib_names.patch             # [win and openssl != "1.1.1"]
+    - windows_ssl_lib_names_openssl111.patch  # [win and openssl == "1.1.1"]
 
 build:
   number: 1000

--- a/recipe/windows_ssl_lib_names_openssl111.patch
+++ b/recipe/windows_ssl_lib_names_openssl111.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index 5eb54b4..24d1566 100644
+--- a/setup.py
++++ b/setup.py
+@@ -192,7 +192,10 @@ if not "win32" in sys.platform:
+ if "win32" in sys.platform:
+   EXTENSION_LIBRARIES += ('advapi32', 'ws2_32',)
+ if BUILD_WITH_SYSTEM_OPENSSL:
+-  EXTENSION_LIBRARIES += ('ssl', 'crypto',)
++  if not "win32" in sys.platform:
++    EXTENSION_LIBRARIES += ('ssl', 'crypto',)
++  else:
++    EXTENSION_LIBRARIES += ('libssl', 'libcrypto',)
+ if BUILD_WITH_SYSTEM_ZLIB:
+   EXTENSION_LIBRARIES += ('z',)
+ if BUILD_WITH_SYSTEM_CARES:


### PR DESCRIPTION
Update the recipe and patches for the 1.16.0 release.

Add a second windows_ssl_lib_names patch with the correct library names for OpenSSL 1.1.1.

closes #2