### PR TITLE
relax setuptools constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/grpcio-feedstoc
 
 Summary: HTTP/2-based RPC framework
 
+Development: https://pypi.org/project/grpcio/
+
 Current build status
 ====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0001-fix-win-commands.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [python_impl == 'pypy']
 
 requirements:
@@ -24,8 +24,7 @@ requirements:
   host:
     - python
     - pip
-    # TODO evaluate if this can be relaxed
-    - setuptools <48.0.0a0
+    - setuptools
     - cython
     - six >=1.5.2
     - zlib
@@ -63,6 +62,7 @@ about:
   license_file: LICENSE
   license_family: APACHE
   summary: HTTP/2-based RPC framework
+  dev_url: https://pypi.org/project/grpcio/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
I believe the setuptools constraint is why you're not getting the python 3.9 migration PR.
The good news though is that it is a `host` dependency, so we'll just need to see if things can still build...

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
